### PR TITLE
Add basic profiling option for exports

### DIFF
--- a/.github/actions/OGD_config/action.yml
+++ b/.github/actions/OGD_config/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "Logging level to use for export process"
     required: true
     default: "INFO"
+  with_profiling:
+    description: "Whether to run the profiler during execution"
+    required: false
+    default: "False"
 runs:
   using: "composite"
   steps:
@@ -56,6 +60,9 @@ runs:
       shell: bash
     - name: Set Logger level
       run: sed -i 's/INFO/${{inputs.log_level}}/g' config/config.py
+      shell: bash
+    - name: Set Profiling
+      run: sed -i 's/"WITH_PROFILING"\s*:\s*False/"WITH_PROFILING":${{inputs.with_profilng}}/g' config/config.py
       shell: bash
     - name: Set Slice Size
       run: sed -i 's/"BATCH_SIZE"\s*:\s*1000,/"BATCH_SIZE":${{inputs.slice_size}},/g' config/config.py

--- a/.github/actions/OGD_config/action.yml
+++ b/.github/actions/OGD_config/action.yml
@@ -62,7 +62,7 @@ runs:
       run: sed -i 's/INFO/${{inputs.log_level}}/g' config/config.py
       shell: bash
     - name: Set Profiling
-      run: sed -i 's/"WITH_PROFILING"\s*:\s*False/"WITH_PROFILING":${{inputs.with_profilng}}/g' config/config.py
+      run: sed -i 's/"WITH_PROFILING"\s*:\s*False/"WITH_PROFILING":${{inputs.with_profiling}}/g' config/config.py
       shell: bash
     - name: Set Slice Size
       run: sed -i 's/"BATCH_SIZE"\s*:\s*1000,/"BATCH_SIZE":${{inputs.slice_size}},/g' config/config.py

--- a/.github/workflows/CI_OGD.yml
+++ b/.github/workflows/CI_OGD.yml
@@ -54,6 +54,7 @@ jobs:
         sql_user: ${{secrets.SQL_USER}}
         sql_pass: ${{secrets.SQL_PASS}}
         log_level: "INFO"
+        with_profiling": "True"
     - name: Set up Schema File for Crystal
       uses: ./.github/actions/OGD_schema
       with:

--- a/.github/workflows/CI_OGD.yml
+++ b/.github/workflows/CI_OGD.yml
@@ -48,13 +48,13 @@ jobs:
     - name: Set up Config File
       uses: ./.github/actions/OGD_config
       with:
-        vpn_user: ${{secrets.VPN_USER}}
-        vpn_pass: ${{secrets.VPN_PASS}}
+        ssh_user: ${{secrets.VPN_USER}}
+        ssh_pass: ${{secrets.VPN_PASS}}
         sql_host: ${{vars.FD_LOGGER_HOST}}
         sql_user: ${{secrets.SQL_USER}}
         sql_pass: ${{secrets.SQL_PASS}}
         log_level: "INFO"
-        with_profiling": "True"
+        with_profiling: "True"
     - name: Set up Schema File for Crystal
       uses: ./.github/actions/OGD_schema
       with:

--- a/config/config.py.template
+++ b/config/config.py.template
@@ -3,6 +3,7 @@ settings = {
     "LOG_FILE":False,
     "DEBUG_LEVEL":"INFO",
     "FAIL_FAST":False,
+    "WITH_PROFILING":False,
     "FILE_INDEXING" : 
     {
         "LOCAL_DIR"     : "./data/",

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 # import standard libraries
 import cProfile
+import pstats
 #import datetime
 import argparse
 import os
@@ -33,7 +34,11 @@ parser = OGDParsers.CommandParser(games_list=games_list)
 
 args : Namespace = parser.parse_args()
 
+
 success : bool
+if config.WithProfiling:
+    profiler = cProfile.Profile()
+    profiler.enable()
 if args is not None:
     cmd = (args.command or "help").lower()
     dest = Path(args.destination if args.destination != "" else "./") if 'destination' in args else config.DataDirectory
@@ -58,5 +63,9 @@ if args is not None:
 else:
     print(f"Need to enter a command!")
     success = False
+if config.WithProfiling:
+    profiler.disable()
+    profile = pstats.Stats(profiler).print_stats()
+
 if not success:
     sys.exit(1)

--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ else:
     success = False
 if config.WithProfiling:
     profiler.disable()
-    profile = pstats.Stats(profiler).print_stats()
+    profile = pstats.Stats(profiler).sort_stats(pstats.SortKey.CUMULATIVE).print_stats('ogd', .1)
 
 if not success:
     sys.exit(1)

--- a/main.py
+++ b/main.py
@@ -65,7 +65,8 @@ else:
     success = False
 if config.WithProfiling:
     profiler.disable()
-    profile = pstats.Stats(profiler).sort_stats(pstats.SortKey.CUMULATIVE).print_stats('ogd', .1)
+    profile = pstats.Stats(profiler)
+    profile.sort_stats(pstats.SortKey.CUMULATIVE).print_stats('ogd', .1)
 
 if not success:
     sys.exit(1)

--- a/src/ogd/core/schemas/configs/ConfigSchema.py
+++ b/src/ogd/core/schemas/configs/ConfigSchema.py
@@ -120,6 +120,13 @@ class ConfigSchema(Schema):
         return self._fail_fast
 
     @property
+    def WithProfiling(self) -> bool:
+        """
+        Whether to track and include profiling data in the output or not.
+        """
+        return self._with_profiling
+
+    @property
     def FileIndexConfig(self) -> FileIndexingSchema:
         """
         A collection of settings for indexing output files.

--- a/src/ogd/core/schemas/configs/ConfigSchema.py
+++ b/src/ogd/core/schemas/configs/ConfigSchema.py
@@ -24,13 +24,14 @@ class ConfigSchema(Schema):
         :param all_elements: A dictionary mapping config item names to their configured values. These will be checked and made available through the ConfigSchema properties.
         :type all_elements: Dict[str, Any]
         """
-        self._log_file   : bool
-        self._batch_size : int
-        self._dbg_level  : int
-        self._fail_fast  : bool
-        self._file_idx   : FileIndexingSchema
-        self._data_src   : Dict[str, DataSourceSchema]
-        self._game_src_map : Dict[str, GameSourceSchema]
+        self._log_file       : bool
+        self._batch_size     : int
+        self._dbg_level      : int
+        self._fail_fast      : bool
+        self._with_profiling : bool
+        self._file_idx       : FileIndexingSchema
+        self._data_src       : Dict[str, DataSourceSchema]
+        self._game_src_map   : Dict[str, GameSourceSchema]
 
         self._legacy_elems : LegacyConfigSchema = LegacyConfigSchema(name=f"{name} Legacy", all_elements=all_elements)
         if "LOG_FILE" in all_elements.keys():
@@ -53,6 +54,11 @@ class ConfigSchema(Schema):
         else:
             self._fail_fast = False
             Logger.Log(f"{name} config does not have a 'FAIL_FAST' element; defaulting to fail_fast={self._fail_fast}", logging.WARN)
+        if "WITH_PROFILING" in all_elements.keys():
+            self._with_profiling = ConfigSchema._parseProfiling(all_elements["WITH_PROFILING"])
+        else:
+            self._with_profiling = False
+            Logger.Log(f"{name} config does not have a 'WITH_PROFILING' element; defaulting to with_profiling={self._fail_fast}", logging.WARN)
         if "FILE_INDEXING" in all_elements.keys():
             self._file_idx = ConfigSchema._parseFileIndexing(all_elements["FILE_INDEXING"])
         else:
@@ -207,6 +213,25 @@ class ConfigSchema(Schema):
         else:
             ret_val = False
             Logger.Log(f"Config fail fast was unexpected type {type(fail_fast)}, defaulting to False.", logging.WARN)
+        return ret_val
+
+    @staticmethod
+    def _parseProfiling(with_profiling) -> bool:
+        ret_val : bool
+        if isinstance(with_profiling, bool):
+            ret_val = with_profiling
+        elif isinstance(with_profiling, str):
+            match with_profiling.upper():
+                case "TRUE":
+                    ret_val = True
+                case "FALSE":
+                    ret_val = False
+                case _:
+                    ret_val = False
+                    Logger.Log(f"Config with_profiling had unexpected value {with_profiling}, defaulting to False.", logging.WARN)
+        else:
+            ret_val = False
+            Logger.Log(f"Config with_profiling was unexpected type {type(with_profiling)}, defaulting to False.", logging.WARN)
         return ret_val
 
     @staticmethod


### PR DESCRIPTION
This adds the option to include basic profiler information, printing the top 10% of cumulative time-costing functions in the `ogd` namespace (technically, anything with ogd in the function/path, but realistically 'ogd' isn't a common series of letters).

Resolves #213 