### PR TITLE
Aqualab: Split survey responses in `SurveyCompleted` to own columns

### DIFF
--- a/src/ogd/games/AQUALAB/AqualabLoader.py
+++ b/src/ogd/games/AQUALAB/AqualabLoader.py
@@ -228,6 +228,8 @@ class AqualabLoader(GeneratorLoader):
                     ret_val = SuccessfulAdvice.SuccessfulAdvice(params=extractor_params, job_map=self._job_map)
                 case "SurveyCompleted":
                     ret_val = SurveyCompleted.SurveyCompleted(params=extractor_params)
+                case "SurveyItemResponse":
+                    ret_val = SurveyItemResponse.SurveyItemResponse(params=extractor_params, target_survey=schema_args.get("target", "NO TARGET CONFIGURED"))
                 case _:
                     Logger.Log(f"'{feature_type}' is not a valid per-count feature type for Aqualab.")
         return ret_val

--- a/src/ogd/games/AQUALAB/AqualabLoader.py
+++ b/src/ogd/games/AQUALAB/AqualabLoader.py
@@ -229,7 +229,9 @@ class AqualabLoader(GeneratorLoader):
                 case "SurveyCompleted":
                     ret_val = SurveyCompleted.SurveyCompleted(params=extractor_params)
                 case "SurveyItemResponse":
-                    ret_val = SurveyItemResponse.SurveyItemResponse(params=extractor_params, target_survey=schema_args.get("target", "NO TARGET CONFIGURED"))
+                    _target = schema_args.get("target", "NO TARGET CONFIGURED")
+                    _retest = schema_args.get("retest", False)
+                    ret_val = SurveyItemResponse.SurveyItemResponse(params=extractor_params, target_survey=_target, retest=_retest)
                 case _:
                     Logger.Log(f"'{feature_type}' is not a valid per-count feature type for Aqualab.")
         return ret_val

--- a/src/ogd/games/AQUALAB/features/SurveyCompleted.py
+++ b/src/ogd/games/AQUALAB/features/SurveyCompleted.py
@@ -61,13 +61,10 @@ class SurveyCompleted(PerCountFeature):
         return
 
     def _getFeatureValues(self) -> List[Any]:
-        return [self._completed, self._responses]
+        return [self._completed, self.KNOWN_SURVEY_NAMES[self.CountIndex], self._responses]
 
     def Subfeatures(self) -> List[str]:
         return ["Name", "Responses"]
-
-    def _getSubfeatureValues(self) -> List[Any]:
-        return [self.KNOWN_SURVEY_NAMES[self.CountIndex], self._responses]
 
     @staticmethod
     def MinVersion() -> Optional[str]:

--- a/src/ogd/games/AQUALAB/features/SurveyCompleted.py
+++ b/src/ogd/games/AQUALAB/features/SurveyCompleted.py
@@ -64,10 +64,10 @@ class SurveyCompleted(PerCountFeature):
         return [self._completed, self._responses]
 
     def Subfeatures(self) -> List[str]:
-        return ["Responses"]
+        return ["Name", "Responses"]
 
     def _getSubfeatureValues(self) -> List[Any]:
-        return [self._responses]
+        return [self.KNOWN_SURVEY_NAMES[self.CountIndex], self._responses]
 
     @staticmethod
     def MinVersion() -> Optional[str]:

--- a/src/ogd/games/AQUALAB/features/SurveyCompleted.py
+++ b/src/ogd/games/AQUALAB/features/SurveyCompleted.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, List, Optional
 from ogd.core.generators.Generator import GeneratorParameters
 from ogd.core.generators.extractors.PerCountFeature import PerCountFeature
@@ -41,13 +42,13 @@ class SurveyCompleted(PerCountFeature):
         survey_name = event.EventData.get("display_event_id", None)
         
         if not survey_name:
-            Logger.Log("Missing display_event_id in survey event", level="WARNING")
+            Logger.Log("Missing display_event_id in survey event", level=logging.WARNING)
             return False
             
         try:
             expected_index = self.KNOWN_SURVEY_NAMES.index(survey_name)
         except ValueError:
-            Logger.Log(f"Unrecognized survey name: {survey_name}", level="WARNING")
+            Logger.Log(f"Unrecognized survey name: {survey_name}", level=logging.WARNING)
             return False
             
         return expected_index == self.CountIndex

--- a/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
+++ b/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
@@ -81,6 +81,7 @@ class SurveyItemResponse(PerCountFeature):
         else:
             return ["Prompt", "Count"]
 
+    @staticmethod
     def AvailableModes() -> List[ExtractionMode]:
         return [ExtractionMode.SESSION, ExtractionMode.PLAYER]
 

--- a/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
+++ b/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
@@ -55,7 +55,7 @@ class SurveyItemResponse(PerCountFeature):
         if len(_responses) > self.CountIndex:
             self._prompt = _responses[self.CountIndex].get("prompt", None)
             # If it was the first time they got the survey, 
-            if self._response_count == 0:
+            if self._response_count == 1:
                 self._response = _responses[self.CountIndex].get("response", None)
             elif self._retest:
                 self._retest_response = _responses[self.CountIndex].get("response", None)

--- a/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
+++ b/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
@@ -12,6 +12,7 @@ class SurveyItemResponse(PerCountFeature):
         super().__init__(params=params)
         self._target_survey = target_survey
         self._response = None
+        self._prompt = None
         self._response_count = 0
 
     @classmethod
@@ -49,6 +50,7 @@ class SurveyItemResponse(PerCountFeature):
         _responses = event.EventData.get("responses", {})
         if len(_responses) > self.CountIndex:
             self._response = _responses[self.CountIndex].get("response", None)
+            self._prompt = _responses[self.CountIndex].get("prompt", None)
             if self._response:
                 self._response_count += 1
             else:
@@ -60,10 +62,10 @@ class SurveyItemResponse(PerCountFeature):
         return
 
     def _getFeatureValues(self) -> List[Any]:
-        return [self._response, self._response_count]
+        return [self._response, self._prompt, self._response_count]
 
     def Subfeatures(self) -> List[str]:
-        return ["Count"]
+        return ["Prompt", "Count"]
 
     @staticmethod
     def MinVersion() -> Optional[str]:

--- a/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
+++ b/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
@@ -70,16 +70,10 @@ class SurveyItemResponse(PerCountFeature):
         return
 
     def _getFeatureValues(self) -> List[Any]:
-        if self._retest:
-            return [self._response, self._retest_response, self._prompt, self._response_count]
-        else:
-            return [self._response, self._prompt, self._response_count]
+        return [self._response, self._retest_response, self._prompt, self._response_count]
 
     def Subfeatures(self) -> List[str]:
-        if self._retest:
-            return ["Retest", "Prompt", "Count"]
-        else:
-            return ["Prompt", "Count"]
+        return ["Retest", "Prompt", "Count"]
 
     @staticmethod
     def AvailableModes() -> List[ExtractionMode]:

--- a/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
+++ b/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Any, List, Optional
+from ogd.core.generators.Generator import GeneratorParameters
+from ogd.core.generators.extractors.PerCountFeature import PerCountFeature
+from ogd.common.models.Event import Event
+from ogd.common.models.enums.ExtractionMode import ExtractionMode
+from ogd.common.models.FeatureData import FeatureData
+from ogd.common.utils.Logger import Logger
+
+class SurveyItemResponse(PerCountFeature):
+    def __init__(self, params: GeneratorParameters, target_survey:str):
+        super().__init__(params=params)
+        self._target_survey = target_survey
+        self._response = None
+        self._response_count = 0
+
+    @classmethod
+    def _eventFilter(cls, mode: ExtractionMode) -> List[str]:
+        return ["survey_submitted"]
+
+    @classmethod
+    def _featureFilter(cls, mode: ExtractionMode) -> List[str]:
+        return []
+
+    def _validateEventCountIndex(self, event: Event) -> bool:
+        """SurveyItemResponse implementation of event validation against CountIndex.
+
+        This is a slight abuse of the function, as we're ignoring the actual CountIndex here.
+        Really, just validating the event against a target.
+        Basic idea is, this feature is operating on events that encode a collection of items, namely responses.
+        Thus, rather than looking for an event that has a single item to match against the Extractor instance's
+        index, we're looking for the event that will contain the item matching CountIndex.
+        The rest of the Extractor's logic will handle retrieval of the response from the collection.
+
+        :param event: The event to be validated
+        :type event: Event
+        :return: True if the event was for the survey whose name is indicated as the target survey, otherwise False
+        :rtype: bool
+        """
+        survey_name = event.EventData.get("display_event_id", None)
+        
+        if not survey_name:
+            Logger.Log("Missing display_event_id in survey event", level=logging.WARNING)
+            return False
+            
+        return survey_name == self._target_survey
+
+    def _updateFromEvent(self, event: Event) -> None:
+        _responses = event.EventData.get("responses", {})
+        if len(_responses) > self.CountIndex:
+            self._response = _responses[self.CountIndex].get("response", None)
+            if self._response:
+                self._response_count += 1
+            else:
+                Logger.Log(f"SurveyItemResponse feature for {self._target_survey} did not get a response value for the response at index {self.CountIndex}!", logging.WARN)
+        else:
+            Logger.Log(f"SurveyItemResponse feature for {self._target_survey} got a survey_submitted event with fewer than {self.CountIndex} items!", logging.WARN)
+
+    def _updateFromFeatureData(self, feature: FeatureData):
+        return
+
+    def _getFeatureValues(self) -> List[Any]:
+        return [self._response, self._response_count]
+
+    def Subfeatures(self) -> List[str]:
+        return ["Count"]
+
+    @staticmethod
+    def MinVersion() -> Optional[str]:
+        return "1"
+
+
+
+

--- a/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
+++ b/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
@@ -62,7 +62,6 @@ class SurveyItemResponse(PerCountFeature):
             else:
                 Logger.Log(f"SurveyItemResponse feature for {self._target_survey} had an unexpected retest!", logging.WARN)
                 self._response = _responses[self.CountIndex].get("response", None)
-
         else:
             Logger.Log(f"SurveyItemResponse feature for {self._target_survey} got a survey_submitted event with fewer than {self.CountIndex} items!", logging.WARN)
 

--- a/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
+++ b/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
@@ -70,10 +70,16 @@ class SurveyItemResponse(PerCountFeature):
         return
 
     def _getFeatureValues(self) -> List[Any]:
-        return [self._response, self._prompt, self._response_count]
+        if self._retest:
+            return [self._response, self._retest_response, self._prompt, self._response_count]
+        else:
+            return [self._response, self._prompt, self._response_count]
 
     def Subfeatures(self) -> List[str]:
-        return ["Prompt", "Count"]
+        if self._retest:
+            return ["Retest", "Prompt", "Count"]
+        else:
+            return ["Prompt", "Count"]
 
     @staticmethod
     def MinVersion() -> Optional[str]:

--- a/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
+++ b/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
@@ -9,13 +9,13 @@ from ogd.common.utils.Logger import Logger
 
 class SurveyItemResponse(PerCountFeature):
     def __init__(self, params: GeneratorParameters, target_survey:str, retest:bool=False):
-        super().__init__(params=params)
         self._target_survey = target_survey
         self._response = None
         self._prompt = None
         self._response_count = 0
         self._retest = retest
         self._retest_response = None
+        super().__init__(params=params)
 
     @classmethod
     def _eventFilter(cls, mode: ExtractionMode) -> List[str]:
@@ -80,6 +80,9 @@ class SurveyItemResponse(PerCountFeature):
             return ["Retest", "Prompt", "Count"]
         else:
             return ["Prompt", "Count"]
+
+    def AvailableModes() -> List[ExtractionMode]:
+        return [ExtractionMode.SESSION, ExtractionMode.PLAYER]
 
     @staticmethod
     def MinVersion() -> Optional[str]:

--- a/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
+++ b/src/ogd/games/AQUALAB/features/SurveyItemResponse.py
@@ -8,7 +8,7 @@ from ogd.common.models.FeatureData import FeatureData
 from ogd.common.utils.Logger import Logger
 
 class SurveyItemResponse(PerCountFeature):
-    def __init__(self, params: GeneratorParameters, target_survey:str, retest:bool):
+    def __init__(self, params: GeneratorParameters, target_survey:str, retest:bool=False):
         super().__init__(params=params)
         self._target_survey = target_survey
         self._response = None

--- a/src/ogd/games/AQUALAB/features/__init__.py
+++ b/src/ogd/games/AQUALAB/features/__init__.py
@@ -49,6 +49,7 @@ __all__ = [
     "SessionJobsCompleted",
     "SuccessfulAdvice",
     "SurveyCompleted",
+    "SurveyItemResponse",
     "SwitchJobsCount",
     "SyncCompletionTime",
     "TankRulesCount",
@@ -124,6 +125,7 @@ from . import SessionID
 from . import SessionJobsCompleted
 from . import SuccessfulAdvice
 from . import SurveyCompleted
+from . import SurveyItemResponse
 from . import SwitchJobsCount
 from . import SyncCompletionTime
 from . import TankRulesCount

--- a/src/ogd/games/AQUALAB/schemas/AQUALAB.json.template
+++ b/src/ogd/games/AQUALAB/schemas/AQUALAB.json.template
@@ -868,6 +868,302 @@
                     }
                 }
             },
+            "DemographicItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "demographics",
+                "retest": false,
+                "count": 4,
+                "prefix": "dem",
+                "description": "Responses to each item on the demographics survey",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "AffectItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "affective",
+                "retest": true,
+                "count": 2,
+                "prefix": "aff",
+                "description": "Responses to each item on the affective state survey",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Retest": {
+                        "description": "The response the player gave upon taking the survey a second time",
+                        "return_type": "int | str"
+                    },
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "ScienceEfficacyItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "science-efficacy",
+                "retest": true,
+                "count": 7,
+                "prefix": "scieff",
+                "description": "Responses to each item on the science self-efficacy survey",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Retest": {
+                        "description": "The response the player gave upon taking the survey a second time",
+                        "return_type": "int | str"
+                    },
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "ScienceIdentityItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "science-identity",
+                "retest": true,
+                "count": 4,
+                "prefix": "sciid",
+                "description": "Responses to each item on the science identity survey",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Retest": {
+                        "description": "The response the player gave upon taking the survey a second time",
+                        "return_type": "int | str"
+                    },
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "ScienceInterestItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "science-interest",
+                "retest": true,
+                "count": 4,
+                "prefix": "sciint",
+                "description": "Responses to each item on the science interest survey",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Retest": {
+                        "description": "The response the player gave upon taking the survey a second time",
+                        "return_type": "int | str"
+                    },
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "HansonInterestsItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "interest-items-hanson-2021",
+                "retest": false,
+                "count": 12,
+                "prefix": "int",
+                "description": "Responses to each item on the Hanson interests survey",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "Values1ItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "values-1",
+                "retest": false,
+                "count": 3,
+                "prefix": "val1",
+                "description": "Responses to each item on the values survey, part 1",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "Values2ItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "values-2",
+                "retest": false,
+                "count": 3,
+                "prefix": "val2",
+                "description": "Responses to each item on the values survey, part 2",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "Values3ItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "values-3",
+                "retest": false,
+                "count": 3,
+                "prefix": "val3",
+                "description": "Responses to each item on the values survey, part 3",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "Values4ItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "values-4",
+                "retest": false,
+                "count": 3,
+                "prefix": "val4",
+                "description": "Responses to each item on the values survey, part 4",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "Values5ItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "values-5",
+                "retest": false,
+                "count": 3,
+                "prefix": "val5",
+                "description": "Responses to each item on the values survey, part 5",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "Values6ItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "values-6",
+                "retest": false,
+                "count": 3,
+                "prefix": "val6",
+                "description": "Responses to each item on the values survey, part 6",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "Values7ItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "values-7",
+                "retest": false,
+                "count": 3,
+                "prefix": "val7",
+                "description": "Responses to each item on the values survey, part 7",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
+            "EnjoymentItemResponses":{
+                "enabled": true,
+                "type": "SurveyItemResponse",
+                "target": "enjoyment",
+                "retest": false,
+                "count": 7,
+                "prefix": "ejy",
+                "description": "Responses to each item on the enjoyment survey",
+                "return_type": "int | str",
+                "subfeatures": {
+                    "Prompt": {
+                        "description": "The full text content of the prompt",
+                        "return_type": "string"
+                    },
+                    "Count": {
+                        "description": "The number of times the player responded to this survey",
+                        "return_type": "int"
+                    }
+                }
+            },
             "SyncCompletionTime": {
                 "enabled": true,
                 "type": "SyncCompletionTime",

--- a/src/ogd/games/AQUALAB/schemas/AQUALAB.json.template
+++ b/src/ogd/games/AQUALAB/schemas/AQUALAB.json.template
@@ -854,7 +854,7 @@
                 "enabled": true,
                 "type": "SurveyCompleted",
                 "count": "level_range",
-                "prefix": "job",
+                "prefix": "svy",
                 "description": "Survey completed during a job",
                 "return_type": "bool",
                 "subfeatures": {

--- a/src/ogd/games/AQUALAB/schemas/AQUALAB.json.template
+++ b/src/ogd/games/AQUALAB/schemas/AQUALAB.json.template
@@ -856,7 +856,17 @@
                 "count": "level_range",
                 "prefix": "job",
                 "description": "Survey completed during a job",
-                "return_type": "bool"
+                "return_type": "bool",
+                "subfeatures": {
+                    "Name": {
+                        "description": "String name of the survey",
+                        "return_type": "string"
+                    },
+                    "Responses": {
+                        "description": "",
+                        "return_type": "int"
+                    }
+                }
             },
             "SyncCompletionTime": {
                 "enabled": true,


### PR DESCRIPTION
Resolves #295 