### PR TITLE
Set python requirement to 3.11 and up.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ authors = [
 ]
 description = "A package for retrieving and processing event-based video game data. Additional authors: Nick Spevacek, Renee Li, John McCloskey, Zach Studdiford, Glenn Palmer, Haishuo Chen, Daus, Ameya Kshirsagar, Yunqing Xiao, Erik Harpstead, Manuel Jesus Gomez Moratilla"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Turns out, it was at 3.10, so we're not actually 'relaxing' the requirement like the GH issue said. Must have reverted back from the 3.12 requirement at some earlier point and missed it when setting up the issue (or just didn't close the issue).

Anyway, better off going to 3.11 anyway.

Resolves #221 